### PR TITLE
Enforce roles access using Auth0 rules

### DIFF
--- a/03-Calling-an-API/READMEs/02_UserScopesAndRoles.md
+++ b/03-Calling-an-API/READMEs/02_UserScopesAndRoles.md
@@ -1,0 +1,94 @@
+
+## SETUP User Roles and Scopes
+
+we can set a user to be an admin via rules at auth0
+- how do we retrieve this info to be usable in our app?
+#### steps to get this info
+install express-bearer-token and jsonwebtoken
+
+** discovered that we are given the Auth0 access token from auth 0 within the authorization header which gives us access to the following information:
+```
+DECODED { iss: 'https://kurtz.auth0.com/',
+  sub: 'facebook|1500600256637448',
+  aud: [ 'http://localhost:3010', 'https://kurtz.auth0.com/userinfo' ],
+  azp: 'RKGnL320bOoupWZGKhPDNexh303w0vh4',
+  exp: 1501273678,
+  iat: 1501266478,
+  scope: 'openid profile read:messages' }
+```
+
+But this does not give us profile information - which is where the admin privilege has been granted via rules at auth0
+
+- make a call to getClientInfo - profile from auth0 - would have to happen on each request!
+- can we stick on a scope per user via rules? Scope set would contain access roles
+
+
+https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims
+Use the auth0 debug console to follow what you are doing
+
+```
+function (user, context, callback) {
+  //console.log('ASSIGN USER ROLES RULE -- BEGIN');
+  //console.log('USER', user);
+  //console.log('CONTEXT', context);
+  //console.log('THIS', this);// null
+  
+  var clientID = 'RKGnL320bOoupWZGKhPDNexh303w0vh4';
+  var hostname = 'kurtz.auth0.com';
+  var namespace = 'http://localhost:3010/'; 
+  var audiences = ['https://localhost:3010', 
+                   'http://localhost:3010']; 
+  
+  //console.log('CLIENTID', context.clientID);
+  //console.log('HOSTNAME', context.request.hostname);
+  //console.log('AUDIENCE', context.request.query.audience);
+  //context.accessToken['https://localhost:3010/' + 'roles'] = '';
+  
+  if(context.clientID === clientID && 
+     context.request.hostname === hostname && 
+     (audiences.indexOf(context.request.query.audience) > -1)) {  
+    //console.log('CLIENTID PROCEED');
+    assignRoles();
+  }
+  
+  function assignRoles() {
+    var supers = ['rob@robkurtz.net'];
+    var admins = ['rob@robkurtz.net'];
+    var roles = [];
+  
+    if(user.email && (supers.indexOf(user.email.toLowerCase()) > -1)) {
+      roles.push('super');
+    }
+  
+    if(user.email && (admins.indexOf(user.email.toLowerCase()) > -1)) {
+      roles.push('admin');
+    }
+  
+    if(roles.length > 0) {
+      context.accessToken[namespace + 'roles'] = roles;
+    }  
+    
+    //console.log('APPLICABLE ROLES HAVE BEEN ASSIGNED');
+  }
+  
+  //console.log('ASSIGN USER ROLES RULE -- END');
+  callback(null, user, context);
+}
+```
+
+Now our decoded token includes namespaced roles:
+```
+DECODED TOKEN { iss: 'https://kurtz.auth0.com/',
+  sub: 'facebook|1500600256637448',
+  aud: [ 'http://localhost:3010', 'https://kurtz.auth0.com/userinfo' ],
+  azp: 'RKGnL320bOoupWZGKhPDNexh303w0vh4',
+  exp: 1501358550,
+  iat: 1501351350,
+  scope: 'openid profile read:messages',
+  'http://localhost:3010/roles': [ 'super', 'admin' ] }
+```
+
+
+So for now we have figured out how to do this via rules written thru the Auth0 dashboard.
+Next step, is it possible to do this via the Auth0 Mgmt API?
+

--- a/03-Calling-an-API/package.json
+++ b/03-Calling-an-API/package.json
@@ -6,8 +6,8 @@
     "react-scripts": "0.9.5"
   },
   "dependencies": {
-    "axios": "^0.16.2",
     "auth0-js": "^8.8.0",
+    "axios": "^0.16.2",
     "bootstrap": "^3.3.7",
     "cors": "^2.8.1",
     "dotenv": "^4.0.0",
@@ -27,7 +27,7 @@
   "scripts": {
     "start": "npm-run-all --parallel server:start client:start",
     "client:start": "react-scripts start",
-    "server:start": "node server.js",
+    "server:start": "nodemon server.js",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/03-Calling-an-API/server.js
+++ b/03-Calling-an-API/server.js
@@ -7,6 +7,7 @@ const cors = require('cors');
 const morgan = require('morgan');
 require('dotenv').config();
 
+
 if (!process.env.AUTH0_DOMAIN || !process.env.AUTH0_AUDIENCE) {
   throw 'Make sure you have AUTH0_DOMAIN, and AUTH0_AUDIENCE in your .env file'
 }
@@ -14,6 +15,10 @@ if (!process.env.AUTH0_DOMAIN || !process.env.AUTH0_AUDIENCE) {
 app.use(cors());
 app.use(morgan('API Request (port ' + process.env.API_PORT + '): :method :url :status :response-time ms - :res[content-length]'));
 
+// we need to reference audience with a /
+const namespace = process.env.AUTH0_AUDIENCE + '/';
+
+// from Auth0
 const checkJwt = jwt({
   // Dynamically provide a signing key based on the kid in the header and the singing keys provided by the JWKS endpoint.
   secret: jwksRsa.expressJwtSecret({
@@ -29,13 +34,55 @@ const checkJwt = jwt({
   algorithms: ['RS256']
 });
 
+// This was provided by auth0 - still not sure why, there is no way to 
+// provide any other option but to include this with all users. 
+// I much prefer the roles approach
 const checkScopes = jwtAuthz([ 'read:messages' ]);
 
+// The default is an OR check on required roles
+// Specify comparison = 'AND" if you need all roles to 
+const checkRoles = function(namespace, validRoles, comparison = 'OR') {
+
+  if (!Array.isArray(validRoles)){
+    throw new Error('Parameter validRoles must be an array of strings representing the required role(s) for the endpoint(s)');
+  }
+
+  return function(req, res, next) {
+    if (validRoles.length === 0){ return next(); }
+    if (!req.user ) { return new Error(res); }
+
+    // ensure a role key
+    const roleKey = Object.keys(req.user).filter(key => {      
+      return key === (namespace + 'roles');
+    }); 
+    if(!roleKey) { return new Error(res); }
+
+    const userRoles = req.user[roleKey];
+    if (Object.keys(userRoles).length === 0) { return new Error(res); }
+    
+    // default comparison is OR - use as a fallback to any other implementation
+    const allowed = (comparison === 'AND') ?  
+      validRoles.every(function(role){
+        return userRoles.indexOf(role) !== -1;
+      }) : 
+      validRoles.some(function(role){
+        return userRoles.indexOf(role) !== -1;
+      });
+
+    return allowed ?
+      next() :
+      new Error(res);
+  }
+};
+
+// ROUTES
 app.get('/api/public', function(req, res) {
   res.json({ message: "Hello from a public endpoint! You don't need to be authenticated to see this." });
 });
 
-app.get('/api/private', checkJwt, checkScopes, function(req, res) {
+// app.get('/api/private', checkJwt, checkScopes, function(req, res) {
+// app.get('/api/private', checkJwt, checkScopes, checkRoles(namespace, ['admin', 'super', 'contract'], 'AND'), function(req, res) {// shuold fail - no contract roles defined for any users
+app.get('/api/private', checkJwt, checkScopes, checkRoles(namespace, ['admin', 'super', 'contract']), function(req, res) {
   res.json({ message: "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this." });
 });
 

--- a/03-Calling-an-API/src/Ping/Ping.js
+++ b/03-Calling-an-API/src/Ping/Ping.js
@@ -17,6 +17,7 @@ class Ping extends Component {
   securedPing() {
     const { getAccessToken } = this.props.auth;
     const headers = { 'Authorization': `Bearer ${getAccessToken()}`}
+    
     axios.get(`${API_URL}/private`, { headers })
       .then(response => this.setState({ message: response.data.message }))
       .catch(error => this.setState({ message: error.message }));

--- a/03-Calling-an-API/src/Profile/Profile.js
+++ b/03-Calling-an-API/src/Profile/Profile.js
@@ -5,7 +5,9 @@ import './Profile.css';
 class Profile extends Component {
   componentWillMount() {
     this.setState({ profile: {} });
+
     const { userProfile, getProfile } = this.props.auth;
+
     if (!userProfile) {
       getProfile((err, profile) => {
         this.setState({ profile });
@@ -14,6 +16,7 @@ class Profile extends Component {
       this.setState({ profile: userProfile });
     }
   }
+
   render() {
     const { profile } = this.state;
     return (


### PR DESCRIPTION

## SETUP User Roles and Scopes

we can set a user to be an admin via rules at auth0
- how do we retrieve this info to be usable in our app?
#### steps to get this info
install express-bearer-token and jsonwebtoken

** discovered that we are given the Auth0 access token from auth 0 within the authorization header which gives us access to the following information:
```
DECODED { iss: 'https://kurtz.auth0.com/',
  sub: 'facebook|1500600256637448',
  aud: [ 'http://localhost:3010', 'https://kurtz.auth0.com/userinfo' ],
  azp: 'RKGnL320bOoupWZGKhPDNexh303w0vh4',
  exp: 1501273678,
  iat: 1501266478,
  scope: 'openid profile read:messages' }
```

But this does not give us profile information - which is where the admin privilege has been granted via rules at auth0

- make a call to getClientInfo - profile from auth0 - would have to happen on each request!
- can we stick on a scope per user via rules? Scope set would contain access roles


https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims
Use the auth0 debug console to follow what you are doing

```
function (user, context, callback) {
  //console.log('ASSIGN USER ROLES RULE -- BEGIN');
  //console.log('USER', user);
  //console.log('CONTEXT', context);
  //console.log('THIS', this);// null
  
  var clientID = 'RKGnL320bOoupWZGKhPDNexh303w0vh4';
  var hostname = 'kurtz.auth0.com';
  var namespace = 'http://localhost:3010/'; 
  var audiences = ['https://localhost:3010', 
                   'http://localhost:3010']; 
  
  //console.log('CLIENTID', context.clientID);
  //console.log('HOSTNAME', context.request.hostname);
  //console.log('AUDIENCE', context.request.query.audience);
  //context.accessToken['https://localhost:3010/' + 'roles'] = '';
  
  if(context.clientID === clientID && 
     context.request.hostname === hostname && 
     (audiences.indexOf(context.request.query.audience) > -1)) {  
    //console.log('CLIENTID PROCEED');
    assignRoles();
  }
  
  function assignRoles() {
    var supers = ['rob@robkurtz.net'];
    var admins = ['rob@robkurtz.net'];
    var roles = [];
  
    if(user.email && (supers.indexOf(user.email.toLowerCase()) > -1)) {
      roles.push('super');
    }
  
    if(user.email && (admins.indexOf(user.email.toLowerCase()) > -1)) {
      roles.push('admin');
    }
  
    if(roles.length > 0) {
      context.accessToken[namespace + 'roles'] = roles;
    }  
    
    //console.log('APPLICABLE ROLES HAVE BEEN ASSIGNED');
  }
  
  //console.log('ASSIGN USER ROLES RULE -- END');
  callback(null, user, context);
}
```

Now our decoded token includes namespaced roles:
```
DECODED TOKEN { iss: 'https://kurtz.auth0.com/',
  sub: 'facebook|1500600256637448',
  aud: [ 'http://localhost:3010', 'https://kurtz.auth0.com/userinfo' ],
  azp: 'RKGnL320bOoupWZGKhPDNexh303w0vh4',
  exp: 1501358550,
  iat: 1501351350,
  scope: 'openid profile read:messages',
  'http://localhost:3010/roles': [ 'super', 'admin' ] }
```


So for now we have figured out how to do this via rules written thru the Auth0 dashboard.
Next step, is it possible to do this via the Auth0 Mgmt API?

